### PR TITLE
fix form context and add react-hook-form stub

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -24,8 +24,8 @@ type FormFieldContextValue<
   name: TName
 }
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
+const FormFieldContext = React.createContext<FormFieldContextValue | undefined>(
+  undefined
 )
 
 const FormField = <
@@ -44,13 +44,16 @@ const FormField = <
 const useFormField = () => {
   const fieldContext = React.useContext(FormFieldContext)
   const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
-
-  const fieldState = getFieldState(fieldContext.name, formState)
 
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>")
+  }
+
+  const { getFieldState, formState } = useFormContext()
+  const fieldState = getFieldState(fieldContext.name, formState)
 
   const { id } = itemContext
 
@@ -68,8 +71,8 @@ type FormItemContextValue = {
   id: string
 }
 
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
+const FormItemContext = React.createContext<FormItemContextValue | undefined>(
+  undefined
 )
 
 const FormItem = React.forwardRef<

--- a/src/types/react-hook-form.d.ts
+++ b/src/types/react-hook-form.d.ts
@@ -1,0 +1,17 @@
+declare module 'react-hook-form' {
+  import * as React from 'react'
+  export interface FieldValues {
+    [key: string]: any
+  }
+  export type FieldPath<TFieldValues extends FieldValues = FieldValues> = keyof TFieldValues & string
+  export interface ControllerProps<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> {
+    name: TName
+    render: (props: { field: any }) => React.ReactElement
+  }
+  export const Controller: React.FC<any>
+  export const FormProvider: React.FC<any>
+  export function useFormContext(): {
+    getFieldState: (name: any, formState: any) => any
+    formState: any
+  }
+}


### PR DESCRIPTION
## Summary
- safeguard form context lookups and validate usage before accessing state
- add lightweight react-hook-form type stub to satisfy TypeScript

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689fab8b67308324a9db1ab4d065c143